### PR TITLE
Run the app from a fully qualified path

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -46,4 +46,4 @@ ENV __LAMBDA_COMPAT=$__LAMBDA_COMPAT
 
 EXPOSE 8080
 
-CMD node --expose-gc app.js
+CMD node --expose-gc /nodejsAction/app.js


### PR DESCRIPTION
This makes running the runtime non-sensitive to workingdir changes so that that can be changed through docker run commands to instruct the runtime to write elsewhere.