### PR TITLE
SERVERLESS-1465 Update Node.js and Golang versions to more recent ones

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -16,7 +16,8 @@
 #
 
 # build go proxy from source
-FROM golang:1.15 AS builder_source
+ARG GO_PROXY_BASE_IMAGE=golang:1.18
+FROM $GO_PROXY_BASE_IMAGE AS builder_source
 ARG GO_PROXY_GITHUB_USER=nimbella-corp
 ARG GO_PROXY_GITHUB_BRANCH=dev
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
@@ -25,7 +26,7 @@ RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
     mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.15 AS builder_release
+FROM $GO_PROXY_BASE_IMAGE AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
 RUN curl -sL \
     https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
@@ -33,7 +34,7 @@ RUN curl -sL \
     && cd openwhisk-runtime-go-*/main\
     && GO111MODULE=on go build -o /bin/proxy
 
-FROM node:14.15.4-stretch
+FROM node:14-stretch
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=source


### PR DESCRIPTION
1. The Golang version we're building the proxy with is ancient. 1.18 is the most recent and known to work.
2. The Node.js patch version is unnecessarily pinned. We can update to 14.19.3.