### PR TITLE
Slim down the Node.js 14 image

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     ca-certificates \
     # For the proxy.
     unzip \
+    python \
     # Dependencies for the users.
     graphicsmagick \
     imagemagick \

--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -17,60 +17,49 @@
 
 # build go proxy from source
 ARG GO_PROXY_BASE_IMAGE=golang:1.18
-FROM $GO_PROXY_BASE_IMAGE AS builder_source
+FROM $GO_PROXY_BASE_IMAGE AS builder
+
 ARG GO_PROXY_GITHUB_USER=nimbella-corp
 ARG GO_PROXY_GITHUB_BRANCH=dev
-RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
-    https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
-    cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
-    mv proxy /bin/proxy
+RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src \
+  && cd /src \
+  && env GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy main/proxy.go
 
-# or build it from a release
-FROM $GO_PROXY_BASE_IMAGE AS builder_release
-ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
-RUN curl -sL \
-    https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
-    | tar xzf -\
-    && cd openwhisk-runtime-go-*/main\
-    && GO111MODULE=on go build -o /bin/proxy
-
-FROM node:14-stretch
-
-# select the builder to use
-ARG GO_PROXY_BUILD_FROM=source
+FROM node:14-stretch-slim
 
 # Initial update and some basics.
-#
-RUN apt-get update && apt-get install -y \
-    imagemagick \
-    graphicsmagick \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # For npm to work properly.
+    git \
+    ssh \
+    ca-certificates \
+    # For the proxy.
     unzip \
-    && rm -rf /var/lib/apt/lists/*
+    # Dependencies for the users.
+    graphicsmagick \
+    imagemagick \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add sources and copy the package.json to root container,
 # so npm packages from user functions take precendence.
-#
 WORKDIR /nodejsAction
-ADD  . /nodejsAction/
+COPY  . /nodejsAction/
 COPY package.json /
 
 # Customize runtime with additional packages.
 # Install package globally so user packages can override.
-#
-RUN cd / && npm install --no-package-lock --production \
-    && npm cache clean --force
-
-# move nim sdk to node modules directory so that it can be found by node module loader
-RUN mkdir /node_modules/nim && mv /nodejsAction/nim.js /node_modules/nim/index.js
+RUN cd / \
+  && npm install --no-package-lock --production \
+  && npm cache clean --force \
+  && mkdir /node_modules/nim \
+  && mv /nodejsAction/nim.js /node_modules/nim/index.js
 
 ARG __OW_LAMBDA_COMPAT
 ENV __OW_LAMBDA_COMPAT=$__OW_LAMBDA_COMPAT
 
-COPY --from=builder_source /bin/proxy /bin/proxy_source
-COPY --from=builder_release /bin/proxy /bin/proxy_release
-RUN mv /bin/proxy_${GO_PROXY_BUILD_FROM} /bin/proxy
-
-ADD bin/compile /bin/compile
+COPY bin/compile /bin/compile
 ENV OW_COMPILER=/bin/compile
 
 # log initialization errors
@@ -80,4 +69,5 @@ ENV OW_WAIT_FOR_ACK=1
 
 ENV OW_INIT_IN_ACTIONLOOP=/nodejsAction/prelauncher.js
 
+COPY --from=builder /bin/proxy /bin/proxy
 ENTRYPOINT [ "/bin/proxy" ]


### PR DESCRIPTION
This reduces the Node.js 14 runtime image size from 1.18GB to 534MB by:

1. Changing from 14-stretch to 14-stretch-slim.
2. Only building and copying one version of the Golang proxy.

Also cleans up a few things (like not using ADD and arranging lines slightly differently).