### PR TITLE
SERVERLESS-1563 Support ES modules as functions

### DIFF
--- a/core/nodejsActionBase/bin/compile
+++ b/core/nodejsActionBase/bin/compile
@@ -57,8 +57,8 @@ def sources(launcher, source_dir, main):
         # part of package.json.
         parts = main.split(".", 1)
         if len(parts) == 1:
-            if not os.path.isfile("%s/index.js" % source_dir) and not os.path.isfile("%s/package.json" % source_dir):
-                print("Zipped actions must contain either package.json or index.js at the root.")
+            if not os.path.isfile("%s/index.js" % source_dir) and not os.path.isfile("%s/index.mjs" % source_dir) and not os.path.isfile("%s/package.json" % source_dir):
+                print("Zipped actions must contain either package.json or index.[m]js at the root.")
                 sys.exit(1)
 
             main_file = ""


### PR DESCRIPTION
This changes the runner to be able to import ES modules and CommonJS modules in a backwards compatible way so that both ES modules and CommonJS modules are supported as functions.

All tests pass for both Node.js 14 and 18.