### PR TITLE
Add python to Node.js 18 image

### DIFF
--- a/core/nodejs18Action/Dockerfile
+++ b/core/nodejs18Action/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     ca-certificates \
     # For the proxy.
     unzip \
+    python \
     # Dependencies for the users.
     graphicsmagick \
     imagemagick \


### PR DESCRIPTION
The compile script needs python to work correctly. It's necessary for log shipping based use-cases.