### PR TITLE
Include functions deployer in runtime image

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -63,6 +63,13 @@ RUN cd / && npm install --no-package-lock --production \
 # move nim sdk to node modules directory so that it can be found by node module loader
 RUN mkdir /node_modules/nim && mv /nodejsAction/nim.js /node_modules/nim/index.js
 
+# install the functions-deployer (co-exist with nim temporarily)
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
+
 ARG __OW_LAMBDA_COMPAT
 ENV __OW_LAMBDA_COMPAT=$__OW_LAMBDA_COMPAT
 

--- a/core/nodejs18Action/Dockerfile
+++ b/core/nodejs18Action/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update \
     # For the proxy.
     unzip \
     python \
+    # For function-deployer install
+    curl \
     # Dependencies for the users.
     graphicsmagick \
     imagemagick \
@@ -54,6 +56,13 @@ COPY package.json /
 RUN cd / \
   && npm install --no-package-lock --omit=dev \
   && npm cache clean --force
+
+# install the functions-deployer (co-exist with nim temporarily)
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
 
 ARG __OW_LAMBDA_COMPAT
 ENV __OW_LAMBDA_COMPAT=$__OW_LAMBDA_COMPAT


### PR DESCRIPTION
This change adds logic to the docker build to incorporate the functions deployer ('dosls' command) in the runtime image. Remote builds will soon switch to using it, rather than 'nim', after which the 'nim' install will be retired.