### PR TITLE
Faster docker builds when sources change

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -47,18 +47,20 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Add sources and copy the package.json to root container,
+# Copy the package.json to root container,
 # so npm packages from user functions take precendence.
-#
 WORKDIR /nodejsAction
-ADD  . /nodejsAction/
 COPY package.json /
 
 # Customize runtime with additional packages.
 # Install package globally so user packages can override.
-#
-RUN cd / && npm install --no-package-lock --production \
-    && npm cache clean --force
+RUN cd / \
+  && npm install --no-package-lock --omit=dev \
+  && npm cache clean --force
+
+# Copy sources in after copying in package.json and running npm install to
+# enable faster builds after only sources change.
+COPY  . /nodejsAction/
 
 # move nim sdk to node modules directory so that it can be found by node module loader
 RUN mkdir /node_modules/nim && mv /nodejsAction/nim.js /node_modules/nim/index.js

--- a/core/nodejs18Action/Dockerfile
+++ b/core/nodejs18Action/Dockerfile
@@ -43,10 +43,9 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# Add sources and copy the package.json to root container,
+# Copy the package.json to root container,
 # so npm packages from user functions take precendence.
 WORKDIR /nodejsAction
-COPY  . /nodejsAction/
 COPY package.json /
 
 # Customize runtime with additional packages.
@@ -54,6 +53,10 @@ COPY package.json /
 RUN cd / \
   && npm install --no-package-lock --omit=dev \
   && npm cache clean --force
+
+# Copy sources in after copying in package.json and running npm install to
+# enable faster builds after only sources change.
+COPY  . /nodejsAction/
 
 ARG __OW_LAMBDA_COMPAT
 ENV __OW_LAMBDA_COMPAT=$__OW_LAMBDA_COMPAT


### PR DESCRIPTION
Fixes a problem with our Node 14 and 18 runtimes (the only ones we use right now) where subsequent builds on a machine need to download NPM dependencies every time. Node 14 took about 10 mins to run `npm install` and Node 18 took about three minutes for this.

Now, they're cached. Only the first build on a machine needs to download them, unless the package.json changes.