### PR TITLE
Clean up references to nim

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -62,10 +62,7 @@ RUN cd / \
 # enable faster builds after only sources change.
 COPY  . /nodejsAction/
 
-# move nim sdk to node modules directory so that it can be found by node module loader
-RUN mkdir /node_modules/nim && mv /nodejsAction/nim.js /node_modules/nim/index.js
-
-# install the functions-deployer (co-exist with nim temporarily)
+# install the functions-deployer
 ARG DEPLOYER_DOWNLOAD
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \

--- a/core/nodejs18Action/Dockerfile
+++ b/core/nodejs18Action/Dockerfile
@@ -60,7 +60,7 @@ RUN cd / \
 # enable faster builds after only sources change.
 COPY  . /nodejsAction/
 
-# install the functions-deployer (co-exist with nim temporarily)
+# install the functions-deployer
 ARG DEPLOYER_DOWNLOAD
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \


### PR DESCRIPTION
This PR has only comment changes and the overdue removal of ancient support for `nim.js` in `nodejs:14`.

Removing `nim` completely from this runtime requires changing the dependency declaration in the main build for the runtime which is being handled separately.