### PR TITLE
SERVERLESS-2326 | Merge OpenWhisk and Lambda variants of Node.js runtimes together

### DIFF
--- a/core/nodejsActionBase/launcher.js
+++ b/core/nodejsActionBase/launcher.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+const useLambdaRunner = require('/nodejsAction/useLambdaRunner');
+
 try {
   const readline = require('readline');
   const fs = require("fs")
@@ -27,9 +29,9 @@ try {
     } catch (e) {}
   })();
 
-  const lambdaCompat = process.env.__OW_LAMBDA_COMPAT === undefined ? false : process.env.__OW_LAMBDA_COMPAT.toLowerCase() === 'true' && NodeActionLambdaRunner !== undefined;
   const handler = eval('require("./##MAIN_FILE##").##MAIN_FUNC##') // Will be replaced in the compile script with the correct main.
-  const runner = lambdaCompat === false ? new NodeActionRunner(handler) : new NodeActionLambdaRunner(handler);
+
+  const runner = useLambdaRunner(handler) ? new NodeActionLambdaRunner(handler) : new NodeActionRunner(handler);
 
   async function actionLoop() {
     const out = fs.createWriteStream(null,

--- a/core/nodejsActionBase/package.json
+++ b/core/nodejsActionBase/package.json
@@ -7,22 +7,27 @@
     "url": "git@github.com:apache/openwhisk-runtime-nodejs.git"
   },
   "license": "Apache-2.0",
+  "scripts": {
+    "test": "mocha"
+  },
   "devDependencies": {
     "btoa": "1.1.2",
+    "chai": "^4.3.7",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
+    "mocha": "^10.1.0",
     "request": "2.79.0"
   },
   "dependencies": {
-    "openwhisk": "3.21.3",
     "body-parser": "1.18.3",
     "express": "4.16.4",
-    "serialize-error": "3.0.0",
+    "openwhisk": "3.21.3",
     "redis": "2.8.0",
+    "serialize-error": "3.0.0",
     "uuid": "3.3.0"
   }
 }

--- a/core/nodejsActionBase/prelauncher.js
+++ b/core/nodejsActionBase/prelauncher.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+const useLambdaRunner = require('/nodejsAction/useLambdaRunner');
+
 try {
   const readline = require('readline');
   const fs = require("fs")
@@ -29,8 +31,11 @@ try {
     } catch (e) {}
   })();
 
-  const lambdaCompat = process.env.__OW_LAMBDA_COMPAT === undefined ? false : process.env.__OW_LAMBDA_COMPAT.toLowerCase() === 'true' && NodeActionLambdaRunner !== undefined;
-
+  /**
+   * Initializes the user's function. Expected to be called with first line from ActionLoop input.
+   * @param {{ env: Object }} message
+   * @returns {NodeActionRunner | NodeActionLambdaRunner} The runner to use with the function.
+   */
   function doInit(message) {
     if (message.env && typeof message.env == 'object') {
       Object.keys(message.env).forEach(k => {
@@ -45,7 +50,7 @@ try {
 
     return initializeActionHandler(message)
       .then(handler => {
-        return lambdaCompat === false ? new NodeActionRunner(handler) : new NodeActionLambdaRunner(handler);
+        return useLambdaRunner(handler) ? new NodeActionLambdaRunner(handler) : new NodeActionRunner(handler);
       });
   }
 

--- a/core/nodejsActionBase/test/useLambdaRunner.spec.js
+++ b/core/nodejsActionBase/test/useLambdaRunner.spec.js
@@ -1,0 +1,41 @@
+const expect = require('chai').expect;
+
+const useLambdaRunner = require('../useLambdaRunner');
+
+const envVarName = '__OW_LAMBDA_COMPAT';
+
+describe('useLambdaRunner()', function () {
+    beforeEach(function () {
+        delete process.env[envVarName];
+    });
+
+    it(`returns true when env var ${envVarName} is set to "true"`, function () {
+        process.env[envVarName] = 'true';
+
+        expect(useLambdaRunner(undefined)).to.equal(true);
+    });
+
+    it(`returns false when env var ${envVarName} is not set and it is given a function with no parameters`, function () {
+        const fn = function() {};
+
+        expect(useLambdaRunner(fn)).to.equal(false);
+    });
+
+    it(`returns false when env var ${envVarName} is not set and it is given a function with one parameter`, function () {
+        const fn = function(a) {};
+
+        expect(useLambdaRunner(fn)).to.equal(false);
+    });
+
+    it(`returns true when env var ${envVarName} is not set and it is given a function with two parameters`, function () {
+        const fn = function(a, b) {};
+
+        expect(useLambdaRunner(fn)).to.equal(true);
+    });
+
+    it(`returns true when env var ${envVarName} and it is given a function with three parameters`, function () {
+        const fn = function(a, b, c) {};
+
+        expect(useLambdaRunner(fn)).to.equal(true);
+    });
+});

--- a/core/nodejsActionBase/useLambdaRunner.js
+++ b/core/nodejsActionBase/useLambdaRunner.js
@@ -1,0 +1,29 @@
+const envVarName = '__OW_LAMBDA_COMPAT';
+
+/**
+ * Decides, based on environment variables and, if needed, the function signature, where to use the Lambda runner
+ * instead of the OpenWhisk runner.
+ * @param {Function} fn The function.
+ * @returns {boolean} Whether the Lambda runner should be used to run the function.
+ */
+function useLambdaRunner(fn) {
+    // Backwards compat: Deem function to be Lambda if env var is provided. This can be removed when we remove the
+    // Lambda only variant of the Node.js runtime. At that point, we would only use the Lambda runner if we detect that
+    // the function signature is Lambda-like.
+    if (process.env[envVarName] !== undefined && process.env[envVarName].toLowerCase() === 'true') {
+        return true;
+    }
+
+    if (fn.length <= 1) {
+        // Includes no parameter case because we want to treat deployments after GA but before official Lambda support
+        // that have no parameters as OpenWhisk (not Lambda).
+        return false;
+    }
+
+    // Includes >2 parameter cases because we want to maintain compatibility with deployments after GA that have
+    // more than two parameters. We have to choose OW or Lambda for them, so we choose Lambda (not for any
+    // particular reason though).
+    return true;
+}
+
+module.exports = useLambdaRunner;

--- a/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
@@ -24,6 +24,7 @@ import actionContainers.{ActionContainer, BasicActionRunnerTests, ResourceHelper
 import actionContainers.ActionContainer.withContainer
 import actionContainers.ResourceHelpers.ZipBuilder
 import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 abstract class NodeJsActionContainerTests extends BasicActionRunnerTests with WskActorSystem {
 
@@ -1048,5 +1049,38 @@ abstract class NodeJsActionContainerTests extends BasicActionRunnerTests with Ws
         o shouldBe empty
         e shouldBe empty
     })
+  }
+
+  Map(
+    "prelaunched" -> Map.empty[String, String],
+    "non-prelaunched" -> Map("OW_INIT_IN_ACTIONLOOP" -> "")
+  ).foreach { case (name, env) =>
+    it should s"support a function with Lambda signature exported via CommonJS ($name)" in {
+      val (out, err) = withActionContainer(env) { c =>
+        val code =
+          """
+            | module.exports.main = async function (event, context) {
+            |     return {
+            |       event,
+            |       contextKeys: Object.keys(context),
+            |     };
+            | }
+          """.stripMargin
+
+        val (initCode, _) = c.init(initPayload(code))
+        initCode should be(200)
+
+        val (runCode, out) = c.run(runPayload(
+          JsObject(
+            "__ow_headers" -> "x".toJson,
+            "__ow_method" -> "get".toJson,
+            "__ow_path" -> "y".toJson)
+        ))
+        runCode should be(200)
+
+        out.get.fields("contextKeys").convertTo[List[String]] should contain theSameElementsAs List("callbackWaitsForEmptyEventLoop", "done", "succeed", "fail", "getRemainingTimeInMillis")
+        out.get.fields("event") shouldBe JsObject("headers" -> "x".toJson, "httpMethod" -> "GET".toJson, "method" -> "get".toJson, "path" -> "y".toJson)
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR merges the Node.js runtimes we have from one for 14 and one for 18, each with builds parameterized for lambda support (which would allow for a total of four built runtimes in total) to just two without builds parameterized. The end result is two built runtimes in total. Each runtime detects the function signature provided by the user.

This is the first step in our new plan to add Lambda function signature support for all of our runtimes.