### PR TITLE
SERVERLESS-2326 Implement context creation in the non-Lambda runner

### DIFF
--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -120,9 +120,24 @@ class NodeActionRunner {
     }
 
     run(args) {
+        let deadline = Number(process.env['__OW_DEADLINE']);
+        let context = {
+            functionName: process.env['__OW_ACTION_NAME'],
+            functionVersion: process.env['__OW_ACTION_VERSION'],
+            activationId: process.env['__OW_ACTIVATION_ID'],
+            requestId: process.env['__OW_TRANSACTION_ID'],
+            deadline: deadline,
+            apiHost: process.env['__OW_API_HOST'],
+            apiKey: process.env['__OW_API_KEY'] || '',
+            namespace: process.env['__OW_NAMESPACE'],
+            getRemainingTimeInMillis: function() {
+                return deadline - new Date().getTime();
+            }
+        }
+
         return new Promise((resolve, reject) => {
             try {
-                var result = this.userScriptMain(args);
+                var result = this.userScriptMain(args, context);
             } catch (e) {
                 reject(e);
             }

--- a/core/nodejsActionBase/test/useLambdaRunner.spec.js
+++ b/core/nodejsActionBase/test/useLambdaRunner.spec.js
@@ -27,15 +27,15 @@ describe('useLambdaRunner()', function () {
         expect(useLambdaRunner(fn)).to.equal(false);
     });
 
-    it(`returns true when env var ${envVarName} is not set and it is given a function with two parameters`, function () {
+    it(`returns false when env var ${envVarName} is not set and it is given a function with two parameters`, function () {
         const fn = function(a, b) {};
 
-        expect(useLambdaRunner(fn)).to.equal(true);
+        expect(useLambdaRunner(fn)).to.equal(false);
     });
 
-    it(`returns true when env var ${envVarName} and it is given a function with three parameters`, function () {
+    it(`returns false when env var ${envVarName} and it is given a function with three parameters`, function () {
         const fn = function(a, b, c) {};
 
-        expect(useLambdaRunner(fn)).to.equal(true);
+        expect(useLambdaRunner(fn)).to.equal(false);
     });
 });

--- a/core/nodejsActionBase/useLambdaRunner.js
+++ b/core/nodejsActionBase/useLambdaRunner.js
@@ -13,17 +13,6 @@ function useLambdaRunner(fn) {
     if (process.env[envVarName] !== undefined && process.env[envVarName].toLowerCase() === 'true') {
         return true;
     }
-
-    if (fn.length <= 1) {
-        // Includes no parameter case because we want to treat deployments after GA but before official Lambda support
-        // that have no parameters as OpenWhisk (not Lambda).
-        return false;
-    }
-
-    // Includes >2 parameter cases because we want to maintain compatibility with deployments after GA that have
-    // more than two parameters. We have to choose OW or Lambda for them, so we choose Lambda (not for any
-    // particular reason though).
-    return true;
 }
 
 module.exports = useLambdaRunner;


### PR DESCRIPTION
We've "merged" the Lambda and the non-Lambda runtimes with the goal of being able to benefit from Lambda's context capabilities. However, the runner does a lot of more things that don't really make sense outside of a "Lambda compatibility layer" context. Those are:

1. Forcing a Promise return for functions that have more than 1 argument.
2. Supporting a 3rd callback parameter.
3. Mangling the input event if it looks like an HTTP event constructed by the controller.
4. Supporting Lambda-specific capabilities like `callbackWaitsForEmptyEventLoop`.

This backs some of the merge out again and implements context-mapping "natively" in the non-Lambda runner to make it behave like before but pass an additional context parameter.