### PR TITLE
SERVERLESS-2491 Rename action -> function in error messages

### DIFF
--- a/core/nodejsActionBase/bin/compile
+++ b/core/nodejsActionBase/bin/compile
@@ -58,7 +58,7 @@ def sources(launcher, source_dir, main):
         parts = main.split(".", 1)
         if len(parts) == 1:
             if not os.path.isfile("%s/index.js" % source_dir) and not os.path.isfile("%s/index.mjs" % source_dir) and not os.path.isfile("%s/package.json" % source_dir):
-                print("Zipped actions must contain either package.json or index.[m]js at the root.")
+                print("Zipped functions must contain either package.json or index.[m]js at the root.")
                 sys.exit(1)
 
             main_file = ""

--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -50,7 +50,7 @@ function initializeActionHandler(message) {
                 const indexJSExists = fs.existsSync('index.js')
                 const indexMJSExists = fs.existsSync('index.mjs')
                 if (index === undefined && !packageJsonExists && !indexJSExists && !indexMJSExists) {
-                    return Promise.reject('Zipped actions must contain either package.json or index.[m]js at the root.');
+                    return Promise.reject('Zipped functions must contain either package.json or index.[m]js at the root.');
                 }
 
                 let mainFile
@@ -183,14 +183,14 @@ function unzipInTmpDir(zipFileContents) {
             const zipFile = path.join(tmpDir, "action.zip");
             fs.writeFile(zipFile, zipFileContents, "base64", err => {
                 if (!err) resolve(zipFile);
-                else reject("There was an error reading the action archive.");
+                else reject("There was an error reading the function archive.");
             });
         });
     }).then(zipFile => {
         return exec(mkTempCmd).then(tmpDir => {
             return exec("unzip -qq " + zipFile + " -d " + tmpDir)
                 .then(res => path.resolve(tmpDir))
-                .catch(error => Promise.reject("There was an error uncompressing the action archive."));
+                .catch(error => Promise.reject("There was an error uncompressing the function archive."));
         });
     });
 }
@@ -228,7 +228,7 @@ function assertMainIsFunction(handler, name) {
     if (typeof handler === 'function') {
         return Promise.resolve(handler);
     } else {
-        return Promise.reject("Action entrypoint '" + name + "' is not a function.");
+        return Promise.reject("Function entrypoint '" + name + "' is not a function.");
     }
 }
 

--- a/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/NodeJsActionContainerTests.scala
@@ -749,7 +749,7 @@ abstract class NodeJsActionContainerTests extends BasicActionRunnerTests with Ws
 
     checkStreams(out, err, {
       case (o, e) =>
-        (o + e).toLowerCase should include("zipped actions must contain either package.json or index.[m]js at the root.")
+        (o + e).toLowerCase should include("zipped functions must contain either package.json or index.[m]js at the root.")
     })
   }
 


### PR DESCRIPTION
As per title, to be able to eliminate action terminology from error messages.