### PR TITLE
Downgrade npm to version 8 to fix UID remapping issues

### DIFF
--- a/core/nodejs18Action/Dockerfile
+++ b/core/nodejs18Action/Dockerfile
@@ -53,6 +53,9 @@ COPY package.json /
 # Customize runtime with additional packages.
 # Install package globally so user packages can override.
 RUN cd / \
+  # Pinning npm to version 8 as 9 has known issues around UID.
+  # See https://github.com/npm/cli/issues/5889 for example.
+  && npm i -g npm@8 \
   && npm install --no-package-lock --omit=dev \
   && npm cache clean --force
 


### PR DESCRIPTION
Recently, the Node.js docker image was updated from 18.13.0 to 18.14.0 which also caused an npm upgrade from 8.19.3 to 9.3.1.

The 9.x series of npm has made changes in that it stops mucking with the ownership of the installed node_modules. That's causing us trouble right now. A discussion of the matter can be found in https://github.com/npm/cli/issues/5889.

Downgrading npm to 8.x unwedges the issue for now.