### PR TITLE
SERVERLESS-2806 Update node:14 base image to bullseye

### DIFF
--- a/core/nodejs14Action/Dockerfile
+++ b/core/nodejs14Action/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sL \
     && cd openwhisk-runtime-go-*/main\
     && GO111MODULE=on go build -o /bin/proxy
 
-FROM node:14-stretch
+FROM node:14-bullseye
 
 # select the builder to use
 ARG GO_PROXY_BUILD_FROM=source


### PR DESCRIPTION
**Note:** This could be more invasive than #20 since it changes the entire base. We could go either way.

---

Similar to node:18, this updates node:14 to bullseye as well as stretch has been out of support for a while and its repositories have been moved to the archive.