### PR TITLE
Added node.js 24 support

### DIFF
--- a/core/nodejs24Action/Dockerfile
+++ b/core/nodejs24Action/Dockerfile
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# build go proxy from source
+ARG GO_PROXY_BASE_IMAGE=golang:1.22
+FROM $GO_PROXY_BASE_IMAGE AS builder
+
+ARG GO_PROXY_GITHUB_USER=nimbella-corp
+ARG GO_PROXY_GITHUB_BRANCH=dev
+RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src \
+  && cd /src \
+  && env GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy main/proxy.go
+
+FROM node:24-bookworm-slim
+
+# Initial update and some basics.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # For npm to work properly.
+    git \
+    ssh \
+    ca-certificates \
+    # For the proxy.
+    unzip \
+    python3 \
+    # For function-deployer install
+    curl \
+    # Dependencies for the users.
+    graphicsmagick \
+    imagemagick \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy the package.json to root container,
+# so npm packages from user functions take precendence.
+WORKDIR /nodejsAction
+COPY package.json /
+
+# Customize runtime with additional packages.
+# Install package globally so user packages can override.
+RUN cd / \
+  && npm install --no-package-lock --omit=dev \
+  && npm cache clean --force
+
+# Copy sources in after copying in package.json and running npm install to
+# enable faster builds after only sources change.
+COPY  . /nodejsAction/
+
+# install the functions-deployer
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls
+
+ARG __OW_LAMBDA_COMPAT
+ENV __OW_LAMBDA_COMPAT=$__OW_LAMBDA_COMPAT
+
+COPY bin/compile /bin/compile
+ENV OW_COMPILER=/bin/compile
+
+# log initialization errors
+ENV OW_LOG_INIT_ERROR=1
+# the launcher must wait for an ack
+ENV OW_WAIT_FOR_ACK=1
+
+ENV OW_INIT_IN_ACTIONLOOP=/nodejsAction/prelauncher.js
+
+COPY --from=builder /bin/proxy /bin/proxy
+ENTRYPOINT [ "/bin/proxy" ]

--- a/core/nodejs24Action/build.gradle
+++ b/core/nodejs24Action/build.gradle
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'eclipse'
+eclipse {
+    project {
+        natures 'org.eclipse.wst.jsdt.core.jsNature'
+        buildCommand 'org.eclipse.wst.jsdt.core.javascriptValidator'
+    }
+}
+
+ext.dockerImageName = 'action-nodejs-v24'
+apply from: '../../gradle/docker.gradle'
+
+distDocker.dependsOn 'copyPackageJson'
+distDocker.dependsOn 'copyRunner'
+distDocker.dependsOn 'copyCompile'
+distDocker.finalizedBy('cleanup')
+
+task copyPackageJson(type: Copy) {
+    from '../nodejsActionBase/package.json'
+    into '.'
+}
+
+task copyRunner(type: Copy) {
+    from '../nodejsActionBase/runner.js'
+    into '.'
+
+    from '../nodejsActionBase/lambda.js'
+    into '.'
+
+    from '../nodejsActionBase/nim.js'
+    into '.'
+
+    from '../nodejsActionBase/launcher.js'
+    into '.'
+}
+
+task copyCompile(type: Copy) {
+    from '../nodejsActionBase/bin/compile'
+    into './bin'
+}
+
+task cleanup(type: Delete) {
+    delete 'package.json'
+    delete 'launcher.js'
+    delete 'lambda.js'
+    delete 'nim.js'
+    delete 'runner.js'
+    delete 'src'
+    delete 'bin'
+}

--- a/tests/src/test/scala/runtime/actionContainers/NodeJs24ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/NodeJs24ActionContainerTests.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime.actionContainers
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class NodeJs24ActionContainerTests extends NodeJsActionContainerTests {
+  override lazy val nodejsContainerImageName = "action-nodejs-v24"
+  override lazy val nodejsTestDockerImageName = "nodejs24docker"
+}


### PR DESCRIPTION
This PR adds support for Node.js 24 (Krypton) using the node:24-bookworm-slim base image.